### PR TITLE
Explicitly set grpc.WithInsecure() when "--insecure=true" is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,9 @@ func main() {
 		grpc.WithBlock(),
 		grpc.WithTimeout(*timeout),
 	}
-	if !*insecure {
+	if *insecure {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
 		var tlsConfig tls.Config
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tlsConfig)))
 	}


### PR DESCRIPTION
When trying to connect to a Murmur instance where gRPC is enabled without TLS, the following error occurs:

```
$ murmur-cli --insecure=true meta uptime
grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)
```

This patch fixes the issue by adding `grpc.WithInsecure()` to the dial options when `--insecure=true` is set.